### PR TITLE
Align researcher profiles with main site style

### DIFF
--- a/SUGGESTIONS.md
+++ b/SUGGESTIONS.md
@@ -1,0 +1,21 @@
+# Webpage Improvement Ideas
+
+## Obvious Enhancements
+1. **Restore the Portuguese Landing Page**  
+   The header includes a language switcher link to `index-pt.html`, but that file is missing, which creates a broken navigation experience for Portuguese-speaking visitors. Add the localized page or point the link at an existing resource so the toggle works.【F:index.html†L129-L141】
+2. **Fix the Instagram Link Styling**  
+   The Instagram footer link concatenates `hover:text-[--primary-color]` with `transition-colors` (missing a space), so the hover transition never triggers. Insert the missing space to make the hover effect consistent with the other social links.【F:index.html†L346-L364】
+3. **Align Cohort Size Figures**  
+   The Impact section highlights "2,000+" mothers and children, while the Projects section references "over 2,300." Standardize the cohort count to avoid confusing readers.【F:index.html†L210-L236】【F:index.html†L276-L308】
+
+## Less Obvious Opportunities
+1. **Respect Reduced Motion Preferences**  
+   The hero slider auto-plays and the animated sections slide in on scroll. Honor `prefers-reduced-motion` by pausing auto-rotation and simplifying animations for visitors sensitive to motion, improving accessibility compliance.【F:index.html†L62-L118】【F:index.html†L397-L466】
+2. **Preload Above-the-Fold Imagery**  
+   The first hero slide image and the logo are critical visuals. Preloading them (e.g., `<link rel="preload" as="image">`) would reduce the perceived load time on slower connections.【F:index.html†L117-L192】
+3. **Add Structured Data for News Items**  
+   Marking the News & Updates cards with JSON-LD `NewsArticle` schema would help search engines understand and surface the latest studies in rich results, boosting discoverability.【F:index.html†L308-L344】
+4. **Automate Slider Interaction Tests**  
+   Keep the new Playwright test, but extend coverage to validate manual dot navigation and pause-on-hover behavior if introduced, catching regressions in future UI tweaks.【F:tests/hero-slider.spec.ts†L1-L27】
+5. **Introduce Analytics Consent Handling**  
+   If analytics or tracking is added later, plan for a consent banner and region-aware defaults to stay compliant with GDPR/ LGPD regulations, which is especially relevant for international cohorts.【F:index.html†L1-L469】

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,17 @@
+# Review Tasks
+
+## Typo Fix
+- **Issue**: The Instagram footer link merges the `hover:text-[--primary-color]` and `transition-colors` classes because a space is missing between them, preventing the transition class from applying. (See `index.html`, line 362.)
+- **Task**: Insert the missing space so both Tailwind utility classes apply correctly.
+
+## Bug Fix
+- **Issue**: The language switcher in the header links to `index-pt.html`, but that file is absent from the repository, resulting in a broken navigation link. (See `index.html`, lines 134-138, and repository listing.)
+- **Task**: Add the missing Portuguese translation page or adjust the link to point to an existing resource.
+
+## Documentation Discrepancy
+- **Issue**: The impact metrics list "2,000+ Mothers & Children in Cohort" while the projects section describes tracking "over 2,300 children and their mothers," presenting inconsistent cohort counts. (See `index.html`, lines 226 and 300-301.)
+- **Task**: Align the stated cohort size across sections to avoid confusing readers.
+
+## Test Improvement
+- **Issue**: Interactive behaviors such as the hero slider auto-rotation and dot controls currently lack automated coverage even though the logic is implemented in the inline script. (See `index.html`, lines 429-466.)
+- **Task**: Introduce an automated UI test (e.g., Playwright) that loads the page, waits for the slider interval, and asserts that the active slide/dot changes, ensuring regressions are caught.

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -1,0 +1,148 @@
+/* Global design tokens */
+:root {
+  --primary-color: #0ea5e9; /* Sky Blue */
+  --secondary-color: #14b8a6; /* Teal */
+  --accent-color: #10b981; /* Emerald Green */
+  --text-dark: #1e293b;   /* Slate 800 for Text */
+  --text-muted: #64748b;    /* Slate 500 */
+  --bg-primary: #f8fafc;    /* Slate 50 */
+  --bg-secondary: #ffffff;  /* White */
+  --header-bg: #f1f5f9;     /* Slate 100 */
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  background-color: var(--bg-primary);
+  color: var(--text-dark);
+}
+
+.font-poppins {
+  font-family: 'Poppins', sans-serif;
+}
+
+.text-gradient {
+  background: linear-gradient(90deg, var(--primary-color), var(--accent-color));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  text-fill-color: transparent;
+}
+
+/* Navigation enhancements */
+.nav-link-effect {
+  transition: all 0.3s ease-out;
+}
+
+.nav-link-effect:hover {
+  color: var(--primary-color);
+  transform: translateY(-2px);
+  text-shadow: 0 4px 10px rgba(14, 165, 233, 0.4);
+}
+
+.nav-link {
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.nav-link:hover {
+  color: var(--primary-color);
+  transform: translateY(-2px);
+}
+
+/* Scroll progress bar */
+#scroll-progress-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 5px;
+  background-color: transparent;
+  z-index: 1000;
+}
+
+#scroll-progress-indicator {
+  height: 100%;
+  background: linear-gradient(90deg, var(--primary-color), var(--accent-color));
+  width: 0%;
+  transition: width 0.1s linear;
+}
+
+/* Hero slider */
+.slide {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  transition: opacity 1.5s ease-in-out;
+  background-size: cover;
+  background-position: center;
+}
+
+.slide.active {
+  opacity: 1;
+}
+
+/* Scroll-triggered animations */
+.animated-section > * {
+  opacity: 0;
+  transition: opacity 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+    transform 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.animated-section.slide-from-left > * {
+  transform: translateX(-100px);
+}
+
+.animated-section.slide-from-right > * {
+  transform: translateX(100px);
+}
+
+.animated-section.in-view > * {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+/* Card hover utility */
+.card-subtle-hover {
+  transition: transform 0.3s ease-out, box-shadow 0.3s ease-out;
+}
+
+.card-subtle-hover:hover {
+  transform: translateY(-8px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.08);
+}
+
+/* Researcher profile cards */
+.section-card {
+  background: var(--bg-secondary);
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 24px 50px rgba(15, 23, 42, 0.06);
+}
+
+.info-card {
+  background: var(--bg-secondary);
+  border-radius: 22px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.05);
+}
+
+.tag {
+  background-color: rgba(14, 165, 233, 0.14);
+  color: var(--primary-color);
+  border-radius: 9999px;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.accent-bar {
+  width: 100%;
+  height: 3px;
+  background: linear-gradient(90deg, var(--primary-color), var(--accent-color));
+  border-radius: 9999px;
+}

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -1,0 +1,133 @@
+document.addEventListener('DOMContentLoaded', () => {
+  // Update footer years
+  const currentYear = new Date().getFullYear();
+  document.querySelectorAll('[data-current-year]').forEach((el) => {
+    el.textContent = currentYear;
+  });
+
+  // Sticky header shadow
+  const header = document.getElementById('main-header');
+  if (header) {
+    const toggleHeaderShadow = () => {
+      if (window.scrollY > 20) {
+        header.classList.add('shadow-lg');
+      } else {
+        header.classList.remove('shadow-lg');
+      }
+    };
+    window.addEventListener('scroll', toggleHeaderShadow);
+    toggleHeaderShadow();
+  }
+
+  // Mobile navigation
+  const mobileMenuBtn = document.getElementById('mobile-menu-btn');
+  const mobileMenu = document.getElementById('mobile-menu');
+  if (mobileMenuBtn && mobileMenu) {
+    mobileMenuBtn.addEventListener('click', () => {
+      mobileMenu.classList.toggle('hidden');
+    });
+
+    mobileMenu.addEventListener('click', (event) => {
+      if (event.target.tagName === 'A') {
+        mobileMenu.classList.add('hidden');
+      }
+    });
+  }
+
+  // Scroll progress bar
+  const progressBar = document.getElementById('scroll-progress-indicator');
+  if (progressBar) {
+    const updateProgressBar = () => {
+      const { scrollTop, scrollHeight, clientHeight } = document.documentElement;
+      const totalScrollable = scrollHeight - clientHeight;
+      if (totalScrollable > 0) {
+        const scrollPercent = (scrollTop / totalScrollable) * 100;
+        progressBar.style.width = `${scrollPercent}%`;
+      }
+    };
+
+    window.addEventListener('scroll', updateProgressBar);
+    updateProgressBar();
+  }
+
+  // Intersection observer for animated sections
+  const animatedSections = document.querySelectorAll('.animated-section');
+  if (animatedSections.length > 0) {
+    const sectionObserver = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('in-view');
+          } else {
+            entry.target.classList.remove('in-view');
+          }
+        });
+      },
+      { threshold: 0.2 }
+    );
+
+    animatedSections.forEach((section) => sectionObserver.observe(section));
+  }
+
+  // Hero slider logic
+  const slides = document.querySelectorAll('#home .slide');
+  const dotsContainer = document.querySelector('.slider-dots');
+  if (slides.length > 0 && dotsContainer) {
+    let currentSlide = 0;
+    const dots = [];
+    let slideIntervalId = null;
+
+    const goToSlide = (index) => {
+      if (slides[currentSlide]) {
+        slides[currentSlide].classList.remove('active');
+      }
+      if (dots[currentSlide]) {
+        dots[currentSlide].classList.remove('bg-white');
+        dots[currentSlide].classList.add('bg-white/40');
+      }
+
+      currentSlide = (index + slides.length) % slides.length;
+
+      if (slides[currentSlide]) {
+        slides[currentSlide].classList.add('active');
+      }
+      if (dots[currentSlide]) {
+        dots[currentSlide].classList.add('bg-white');
+        dots[currentSlide].classList.remove('bg-white/40');
+      }
+    };
+
+    const startInterval = () => {
+      if (slides.length > 1) {
+        slideIntervalId = window.setInterval(() => {
+          goToSlide(currentSlide + 1);
+        }, 7000);
+      }
+    };
+
+    const resetInterval = () => {
+      if (slideIntervalId) {
+        window.clearInterval(slideIntervalId);
+      }
+      startInterval();
+    };
+
+    slides.forEach((_, index) => {
+      const dot = document.createElement('button');
+      dot.className = 'w-3 h-3 rounded-full bg-white/40 transition-all duration-300 backdrop-blur-sm';
+      dot.addEventListener('click', () => {
+        goToSlide(index);
+        resetInterval();
+      });
+      dotsContainer.appendChild(dot);
+      dots.push(dot);
+    });
+
+    if (dots[0]) {
+      dots[0].classList.add('bg-white');
+      dots[0].classList.remove('bg-white/40');
+    }
+
+    startInterval();
+  }
+});

--- a/docs/RESEARCHER_PAGE_DESIGN.md
+++ b/docs/RESEARCHER_PAGE_DESIGN.md
@@ -1,0 +1,144 @@
+# Researcher Detail Page Design
+
+## 1. Current Landing Page Map
+To keep the new researcher pages visually coherent with the existing landing page, here is a quick map of the major sections already present in `index.html`:
+
+1. **Hero slider (`#home`)** – three-panel carousel with overlay headlines that introduces GPIS.
+2. **Group overview (`#group`)** – mission statement, key metrics, and a featured call-to-action.
+3. **Members highlight (`#members`)** – grid of core team members with roles and social links.
+4. **Projects showcase (`#projects`)** – cards describing ongoing initiatives with tags.
+5. **Impact stats (`#impact`)** – numeric counters for publications, partnerships, etc.
+6. **News & updates (`#news`)** – latest articles and announcements in card layout.
+7. **Partners & supporters (`#partners`)** – sponsor logos with hover effects.
+8. **Contact & newsletter (`#contact`)** – form, location map, and footer with quick links.
+
+These anchors can inform consistent typography, spacing, and color usage for the standalone researcher pages.
+
+## 2. Page Goals
+Each researcher page should:
+- Give visitors a polished, credible snapshot of the individual’s expertise and contributions.
+- Surface reusable content blocks (e.g., publications, projects, media) that can be sourced from structured data.
+- Encourage contact, collaboration, or deeper exploration of the researcher’s work.
+
+## 3. Layout Overview
+1. **Sticky Header & Breadcrumb**
+   - Use the existing translucent header style with navigation back to the main site.
+   - Add a breadcrumb such as `Home → Researchers → Dr. Jane Doe` for orientation.
+
+2. **Hero Profile Banner**
+   - Left: portrait photo in a rounded frame with subtle drop shadow.
+   - Right: name, pronouns, current title, affiliation, quick contact buttons (email, LinkedIn, ORCID).
+   - Background: gradient overlay echoing the primary colors, optionally with a research-themed illustration.
+
+3. **At-a-Glance Quick Facts**
+   - Horizontal info cards for research areas, methodologies, years with GPIS, languages spoken, and availability (e.g., “Open to collaborations”).
+   - Include iconography from Heroicons or similar for visual scanning.
+
+4. **Narrative Biography & Mission**
+   - Two-column layout on desktop: left column for narrative paragraphs; right column for key highlights (e.g., “Leads the Digital Epidemiology Lab”).
+   - Mobile: stack content with generous spacing.
+
+5. **Research Focus Tabs**
+   - Tabbed interface dividing focus areas such as "Digital Epidemiology", "Maternal Health", "Data Governance".
+   - Each tab contains: brief summary, representative projects, relevant metrics.
+
+6. **Active Projects Module**
+   - Card grid pulling from the shared projects data source. Each card shows project name, role, timeline, and CTA to the project detail page.
+   - Highlight the researcher’s specific contribution (e.g., "Principal Investigator", "Data Scientist").
+
+7. **Key Publications & Outputs**
+   - List of up to 6 featured items with title, venue, year, and quick links (PDF, DOI).
+   - Provide filters or tags (e.g., "Journal", "Conference", "Policy Brief").
+   - Include a "View all publications" link if a longer list exists.
+
+8. **Impact Metrics & Recognitions**
+   - Animated counters for citations, grants secured, media mentions.
+   - Carousel or timeline for awards, keynote talks, or recognitions.
+
+9. **Media & Talks Gallery**
+   - Responsive gallery combining embedded videos, audio interviews, and photo highlights.
+   - Lightbox modal for enlarged viewing.
+
+10. **Collaborators & Team**
+    - Avatars of frequent collaborators with roles and quick links to their profiles.
+    - Optionally, a network visualization (static image) for a more advanced interaction.
+
+11. **Contact & Availability CTA**
+    - Primary CTA button ("Request collaboration", "Book office hours") linking to contact form or email.
+    - Secondary CTA for downloading a full CV or biosketch.
+
+12. **Related News & Updates**
+    - Pull latest news posts tagged with the researcher. Each card shows image thumbnail, headline, and publication date.
+
+13. **Footer Consistency**
+    - Reuse the landing page footer with social links and newsletter sign-up.
+
+## 4. Interaction & Accessibility Notes
+- Ensure keyboard navigability for tabs, sliders, and modals (ARIA roles and labels).
+- Maintain high contrast for text against gradient backgrounds.
+- Provide descriptive alt text for portraits, gallery images, and award badges.
+- Use `prefers-reduced-motion` media queries to tone down animations for sensitive users.
+
+## 5. Content Model Recommendations
+To keep the researcher pages scalable, consider structuring the data as follows:
+
+```json
+{
+  "id": "jane-doe",
+  "name": "Dr. Jane Doe",
+  "pronouns": "she/her",
+  "title": "Senior Research Fellow",
+  "affiliation": "Global Public Health Innovation Studio",
+  "contact": {
+    "email": "jane.doe@example.org",
+    "linkedin": "https://linkedin.com/in/janedoe",
+    "orcid": "0000-0002-1234-5678"
+  },
+  "headshot": "/images/researchers/jane-doe.jpg",
+  "bio": ["Paragraph 1", "Paragraph 2"],
+  "focusAreas": [
+    {
+      "name": "Digital Epidemiology",
+      "summary": "Short description...",
+      "projects": ["project-alpha", "project-beta"],
+      "metrics": {"datasets": 5, "publications": 12}
+    }
+  ],
+  "projects": [
+    {
+      "id": "project-alpha",
+      "role": "Principal Investigator",
+      "timeline": "2022 – Present"
+    }
+  ],
+  "publications": [
+    {
+      "title": "Longitudinal Health Analytics...",
+      "venue": "Lancet Digital Health",
+      "year": 2023,
+      "links": {"doi": "https://doi.org/...", "pdf": "/pdfs/..."},
+      "type": "Journal"
+    }
+  ],
+  "awards": [
+    {"title": "Best Paper", "event": "ICHI 2023", "year": 2023}
+  ],
+  "media": [
+    {"type": "video", "title": "Keynote at...", "url": "https://youtu.be/..."}
+  ],
+  "collaborators": ["john-smith", "amara-lee"],
+  "newsTags": ["digital-epidemiology", "maternal-health"],
+  "cta": {
+    "primary": {"label": "Request collaboration", "href": "/contact?to=jane-doe"},
+    "secondary": {"label": "Download CV", "href": "/docs/jane-doe-cv.pdf"}
+  }
+}
+```
+
+With a structured schema, you can programmatically generate pages and keep the homepage sections synchronized.
+
+## 6. Next Steps
+- Approve this layout direction, then replicate similar design frameworks for project and news detail pages.
+- Define shared components (hero, tabbed content, galleries) in your chosen frontend stack to ensure consistency.
+- Align with content owners to gather high-quality assets (headshots, publication lists, videos).
+

--- a/index.html
+++ b/index.html
@@ -7,107 +7,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
-    <style>
-        /* CSS Variables/Utilities */
-        :root {
-            --primary-color: #0ea5e9; /* Sky Blue */
-            --secondary-color: #14b8a6; /* Teal */
-            --accent-color: #10b981; /* Emerald Green */
-            --text-dark: #1e293b;   /* Slate 800 for Text */
-            --text-muted: #64748b;    /* Slate 500 */
-            --bg-primary: #f8fafc;    /* Slate 50 */
-            --bg-secondary: #ffffff;   /* White */
-            --header-bg: #f1f5f9; /* Slate 100 for the new header color */
-        }
-
-        body {
-            font-family: 'Inter', sans-serif;
-            background-color: var(--bg-primary);
-            color: var(--text-dark);
-        }
-        
-        .font-poppins {
-            font-family: 'Poppins', sans-serif;
-        }
-
-        .text-gradient {
-            background: linear-gradient(90deg, var(--primary-color), var(--accent-color));
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-            text-fill-color: transparent;
-        }
-
-        /* Scroll Progress Bar */
-        #scroll-progress-bar {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 5px;
-            background-color: transparent;
-            z-index: 1000;
-        }
-
-        #scroll-progress-indicator {
-            height: 100%;
-            background: linear-gradient(90deg, var(--primary-color), var(--accent-color));
-            width: 0%;
-            transition: width 0.1s linear;
-        }
-        
-        /* Slider Styles */
-        .slide {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            opacity: 0;
-            transition: opacity 1.5s ease-in-out;
-            background-size: cover;
-            background-position: center;
-        }
-        .slide.active {
-            opacity: 1;
-        }
-
-        /* Reversible Scroll-triggered Animations */
-        .animated-section > * {
-            opacity: 0;
-            transition: opacity 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94), transform 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-        }
-        .animated-section.slide-from-left > * {
-            transform: translateX(-100px);
-        }
-        .animated-section.slide-from-right > * {
-            transform: translateX(100px);
-        }
-        .animated-section.in-view > * {
-            opacity: 1;
-            transform: translateX(0);
-        }
-        
-        /* Subtle Card Hover Effect */
-        .card-subtle-hover {
-            transition: transform 0.3s ease-out, box-shadow 0.3s ease-out;
-        }
-        .card-subtle-hover:hover {
-            transform: translateY(-8px);
-            box-shadow: 0 10px 20px rgba(0,0,0,0.08);
-        }
-
-        /* New Header Link Hover Effect */
-        .nav-link-effect {
-            transition: all 0.3s ease-out;
-        }
-        .nav-link-effect:hover {
-            color: var(--primary-color);
-            transform: translateY(-2px);
-            text-shadow: 0 4px 10px rgba(14, 165, 233, 0.4);
-        }
-
-    </style>
+    <link rel="stylesheet" href="assets/css/site.css">
 </head>
 <body class="bg-[--bg-primary]">
 
@@ -244,7 +144,7 @@
                     <!-- Member 1: Christian Loret de Mola Zanatti -->
                     <div class="text-center group">
                         <img src="images/christian-loret-de-mola-zanatti.png" alt="Christian Loret de Mola Zanatti" class="w-40 h-40 mx-auto rounded-full object-cover shadow-lg ring-4 ring-white group-hover:ring-[--accent-color] transition-all duration-300 transform group-hover:scale-105">
-                        <a href="https://orcid.org/0000-0002-5264-5914" target="_blank" rel="noopener noreferrer" class="hover:opacity-80">
+                        <a href="researchers/christian-loret-de-mola-zanatti.html" class="hover:opacity-80">
                             <h3 class="mt-5 text-xl font-bold text-[--text-dark]">Christian Loret de Mola Zanatti</h3>
                         </a>
                         <p class="text-[--text-muted]">Founder and Leader</p>
@@ -252,7 +152,7 @@
                     <!-- Member 2: Rafaela Costa Martins -->
                     <div class="text-center group">
                         <img src="images/rafaela_martins.png" alt="Rafaela Costa Martins" class="w-40 h-40 mx-auto rounded-full object-cover shadow-lg ring-4 ring-white group-hover:ring-[--accent-color] transition-all duration-300 transform group-hover:scale-105">
-                        <a href="https://orcid.org/0000-0003-3538-7228" target="_blank" rel="noopener noreferrer" class="hover:opacity-80">
+                        <a href="researchers/rafaela-costa-martins.html" class="hover:opacity-80">
                             <h3 class="mt-5 text-xl font-bold text-[--text-dark]">Rafaela Costa Martins</h3>
                         </a>
                         <p class="text-[--text-muted]">Researcher</p>
@@ -260,7 +160,7 @@
                     <!-- Member 3: Francine dos Santos Costa -->
                     <div class="text-center group">
                         <img src="images/Francine_costa.png" alt="Francine dos Santos Costa" class="w-40 h-40 mx-auto rounded-full object-cover shadow-lg ring-4 ring-white group-hover:ring-[--accent-color] transition-all duration-300 transform group-hover:scale-105">
-                        <a href="https://orcid.org/0000-0001-9558-937X" target="_blank" rel="noopener noreferrer" class="hover:opacity-80">
+                        <a href="researchers/francine-dos-santos-costa.html" class="hover:opacity-80">
                             <h3 class="mt-5 text-xl font-bold text-[--text-dark]">Francine dos Santos Costa</h3>
                         </a>
                         <p class="text-[--text-muted]">Researcher</p>
@@ -268,7 +168,7 @@
                     <!-- Member 4: Cauane Blumenberg -->
                     <div class="text-center group">
                         <img src="images/cauane.png" alt="Cauane Blumenberg" class="w-40 h-40 mx-auto rounded-full object-cover shadow-lg ring-4 ring-white group-hover:ring-[--accent-color] transition-all duration-300 transform group-hover:scale-105">
-                         <a href="https://orcid.org/0000-0002-4580-3849" target="_blank" rel="noopener noreferrer" class="hover:opacity-80">
+                         <a href="researchers/cauane-blumenberg-silva.html" class="hover:opacity-80">
                             <h3 class="mt-5 text-xl font-bold text-[--text-dark]">Cauane Blumenberg</h3>
                         </a>
                         <p class="text-[--text-muted]">Researcher</p>
@@ -276,7 +176,7 @@
                     <!-- Member 5: Thais Martins Silva -->
                     <div class="text-center group">
                         <img src="images/thais_martins.png" alt="Thais Martins Silva" class="w-40 h-40 mx-auto rounded-full object-cover shadow-lg ring-4 ring-white group-hover:ring-[--accent-color] transition-all duration-300 transform group-hover:scale-105">
-                        <a href="https://orcid.org/0000-0001-5049-2435" target="_blank" rel="noopener noreferrer" class="hover:opacity-80">
+                        <a href="researchers/thais-martins-da-silva.html" class="hover:opacity-80">
                             <h3 class="mt-5 text-xl font-bold text-[--text-dark]">Thais Martins Silva</h3>
                         </a>
                         <p class="text-[--text-muted]">Researcher</p>
@@ -284,7 +184,7 @@
                     <!-- Member 6: Romina Buffarini -->
                     <div class="text-center group">
                         <img src="images/romina_buffarini.png" alt="Romina Buffarini" class="w-40 h-40 mx-auto rounded-full object-cover shadow-lg ring-4 ring-white group-hover:ring-[--accent-color] transition-all duration-300 transform group-hover:scale-105">
-                        <a href="https://orcid.org/0000-0002-6905-8767" target="_blank" rel="noopener noreferrer" class="hover:opacity-80">
+                        <a href="researchers/romina-buffarini.html" class="hover:opacity-80">
                             <h3 class="mt-5 text-xl font-bold text-[--text-dark]">Romina Buffarini</h3>
                         </a>
                         <p class="text-[--text-muted]">Researcher</p>
@@ -367,106 +267,11 @@
                 <span class="opacity-50 hidden sm:inline">|</span>
                 <a href="https://www.ncbi.nlm.nih.gov/sites/myncbi/christian.loret%20de%20mola.1/collections/65988568/public/" target="_blank" rel="noopener noreferrer" class="hover:text-[--primary-color] transition-colors">Publications</a>
             </div>
-            <p class="text-sm text-slate-400">&copy; 2025 GPIS - Health Innovation Research Group. All Rights Reserved.</p>
+            <p class="text-sm text-slate-400">&copy; <span data-current-year></span> GPIS - Health Innovation Research Group. All Rights Reserved.</p>
         </div>
     </footer>
 
-    <!-- JAVASCRIPT LOGIC -->
-    <script>
-        document.addEventListener('DOMContentLoaded', function () {
-            const header = document.getElementById('main-header');
-            const mobileMenuBtn = document.getElementById('mobile-menu-btn');
-            const mobileMenu = document.getElementById('mobile-menu');
-            const progressBar = document.getElementById('scroll-progress-indicator');
-            const animatedSections = document.querySelectorAll('.animated-section');
-
-            // 1. Sticky Header Shadow on Scroll
-            window.addEventListener('scroll', () => {
-                if (window.scrollY > 20) {
-                    header.classList.add('shadow-lg');
-                } else {
-                    header.classList.remove('shadow-lg');
-                }
-            });
-
-            // 2. Mobile Menu Toggle
-            mobileMenuBtn.addEventListener('click', () => {
-                mobileMenu.classList.toggle('hidden');
-            });
-            mobileMenu.addEventListener('click', (e) => {
-                if (e.target.tagName === 'A') {
-                    mobileMenu.classList.add('hidden');
-                }
-            });
-
-            // 3. Scroll Progress Bar
-            function updateProgressBar() {
-                const { scrollTop, scrollHeight, clientHeight } = document.documentElement;
-                if (scrollHeight - clientHeight > 0) {
-                    const scrollPercent = (scrollTop / (scrollHeight - clientHeight)) * 100;
-                    progressBar.style.width = `${scrollPercent}%`;
-                }
-            }
-            window.addEventListener('scroll', updateProgressBar);
-            
-            // 4. Reversible Scroll Animations
-            const sectionObserver = new IntersectionObserver((entries) => {
-                entries.forEach(entry => {
-                    if (entry.isIntersecting) {
-                        entry.target.classList.add('in-view');
-                    } else {
-                        entry.target.classList.remove('in-view');
-                    }
-                });
-            }, {
-                threshold: 0.2 // Trigger when 20% of the section is visible
-            });
-
-            animatedSections.forEach(section => {
-                sectionObserver.observe(section);
-            });
-
-            // 5. Hero Slider Logic
-            const slides = document.querySelectorAll('#home .slide');
-            const dotsContainer = document.querySelector('.slider-dots');
-            let currentSlide = 0;
-            let slideInterval = setInterval(nextSlide, 7000);
-
-            slides.forEach((_, i) => {
-                const dot = document.createElement('button');
-                dot.classList.add('w-3', 'h-3', 'rounded-full', 'bg-white/40', 'transition-all', 'duration-300', 'backdrop-blur-sm');
-                dot.addEventListener('click', () => {
-                    goToSlide(i);
-                });
-                dotsContainer.appendChild(dot);
-            });
-            const dots = dotsContainer.querySelectorAll('button');
-
-            function goToSlide(n) {
-                slides[currentSlide].classList.remove('active');
-                dots[currentSlide].classList.remove('bg-white');
-                dots[currentSlide].classList.add('bg-white/40');
-                
-                currentSlide = (n + slides.length) % slides.length;
-                
-                slides[currentSlide].classList.add('active');
-                dots[currentSlide].classList.add('bg-white');
-                dots[currentSlide].classList.remove('bg-white/40');
-                
-                clearInterval(slideInterval);
-                slideInterval = setInterval(nextSlide, 7000);
-            }
-
-            function nextSlide() {
-                goToSlide(currentSlide + 1);
-            }
-
-            if (dots.length > 0) {
-                dots[0].classList.add('bg-white');
-                dots[0].classList.remove('bg-white/40');
-            }
-        });
-    </script>
+    <script src="assets/js/site.js" defer></script>
 </body>
 </html>
 

--- a/researchers/cauane-blumenberg-silva.html
+++ b/researchers/cauane-blumenberg-silva.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cauane Blumenberg Silva | GPIS Researcher</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Poppins:wght@500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../assets/css/site.css">
+</head>
+<body class="min-h-screen flex flex-col bg-[--bg-primary]">
+  <header class="fixed inset-x-0 top-0 z-40 border-b border-slate-200/70 bg-[--bg-secondary]/90 backdrop-blur">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+      <a href="../index.html" class="flex items-center gap-3 text-sm text-[--text-muted] transition hover:text-[--primary-color]">
+        <img src="../images/logo.png" alt="GPIS logo" class="h-10 w-auto">
+        <div class="leading-tight">
+          <p class="font-semibold text-[--text-dark]">GPIS</p>
+          <p class="text-xs">Health Innovation Research Group</p>
+        </div>
+      </a>
+      <nav class="hidden items-center gap-6 text-sm font-medium text-[--text-muted] md:flex">
+        <a href="../index.html#members" class="nav-link">Back to Members</a>
+        <a href="../index.html#projects" class="nav-link">Projects</a>
+        <a href="../index.html#news" class="nav-link">News</a>
+        <a href="mailto:cauane.epi@gmail.com" class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[--primary-color] to-[--accent-color] px-4 py-2 text-white shadow-sm transition hover:shadow-lg">
+          <span>Contact Cauane</span>
+        </a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="flex-1 pt-28 pb-20">
+    <section class="px-6">
+      <div class="mx-auto max-w-6xl section-card p-10 md:p-12">
+        <div class="flex flex-col gap-10 lg:grid lg:grid-cols-[minmax(0,2fr)_minmax(0,1.05fr)] lg:gap-12">
+          <article class="space-y-8">
+            <div class="flex flex-col-reverse gap-8 lg:flex-row lg:items-center lg:justify-between">
+              <div class="space-y-6">
+                <div class="flex flex-wrap items-center gap-3 text-xs font-semibold uppercase tracking-[0.3em] text-[--primary-color]">
+                  <span>Researcher Profile</span>
+                  <span class="hidden h-1 w-14 rounded-full bg-[--accent-color]/70 sm:block"></span>
+                  <span>GPIS</span>
+                </div>
+                <div class="space-y-3">
+                  <h1 class="text-3xl font-bold text-[--text-dark] sm:text-4xl lg:text-5xl">Cauane Blumenberg Silva</h1>
+                  <p class="max-w-2xl text-lg text-[--text-muted]">Data scientist and epidemiologist connecting advanced analytics to population health decision-making.</p>
+                </div>
+                <div class="flex flex-wrap gap-3">
+                  <span class="tag">Data science</span>
+                  <span class="tag">Digital epidemiology</span>
+                  <span class="tag">Health inequities</span>
+                  <span class="tag">Applied statistics</span>
+                </div>
+              </div>
+              <div class="flex justify-center lg:justify-end">
+                <div class="relative">
+                  <div class="absolute inset-0 -translate-x-2 translate-y-2 rounded-full bg-gradient-to-br from-[--primary-color]/20 to-[--accent-color]/10 blur-xl"></div>
+                  <img src="../images/cauane.png" alt="Portrait of Cauane Blumenberg Silva" class="relative z-10 h-40 w-40 rounded-full object-cover shadow-lg ring-4 ring-[--bg-secondary] outline outline-2 outline-[--primary-color]/20 md:h-48 md:w-48">
+                </div>
+              </div>
+            </div>
+
+            <div class="accent-bar"></div>
+
+            <div class="space-y-6 text-base leading-relaxed text-[--text-muted]">
+              <p>Cauane Blumenberg Silva integrates computer science and epidemiology to unlock insights from complex public health datasets. He completed a PhD in Epidemiology at the Federal University of Pelotas (UFPel) and holds a master&#39;s degree in Computer Science from UFRGS, positioning him at the intersection of health informatics and statistical innovation.</p>
+              <p>At the International Center for Equity in Health (ICEH), Cauane leads teams that design data pipelines, dashboards, and decision-support tools for large-scale studies. His work spans survey methodology, reproducible analytics, and the modeling of behavioral and social determinants of health.</p>
+              <p>Beyond academia, Cauane founded Causale Consultoria, where he partners with organizations to improve data collection and analysis strategies. International experiences, including doctoral research at Università degli Studi di Torino and a postdoctoral fellowship at the Hospital for Sick Children in Canada, inform his global perspective on equitable digital health solutions.</p>
+            </div>
+          </article>
+
+          <aside class="space-y-6">
+            <div class="info-card p-6">
+              <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-[--text-muted]">Quick Facts</h2>
+              <dl class="mt-4 space-y-4 text-sm text-[--text-dark]">
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">Email</dt>
+                  <dd><a href="mailto:cauane.epi@gmail.com" class="text-[--primary-color] hover:text-[--secondary-color]">cauane.epi@gmail.com</a></dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">ORCID</dt>
+                  <dd><a href="https://orcid.org/0000-0002-4580-3849" target="_blank" rel="noopener" class="text-[--primary-color] hover:text-[--secondary-color]">0000-0002-4580-3849</a></dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">Lattes ID</dt>
+                  <dd><a href="http://lattes.cnpq.br/6335726365968711" target="_blank" rel="noopener" class="text-[--primary-color] hover:text-[--secondary-color]">6335726365968711</a></dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">CNPq Award</dt>
+                  <dd class="text-right text-sm text-[--text-muted]">Not currently listed</dd>
+                </div>
+              </dl>
+              <a href="http://lattes.cnpq.br/6335726365968711" target="_blank" rel="noopener" class="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-full bg-gradient-to-r from-[--primary-color] to-[--accent-color] px-4 py-2 text-sm font-semibold text-white transition hover:shadow-lg">View Curriculum Lattes</a>
+            </div>
+
+            <div class="info-card p-6">
+              <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-[--text-muted]">Affiliations</h2>
+              <ul class="mt-4 space-y-3 text-sm text-[--text-dark]">
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--primary-color]"></span>
+                  <span>Health Innovation Research Group (GPIS), Federal University of Rio Grande (FURG)</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--primary-color]"></span>
+                  <span>Causale Consultoria</span>
+                </li>
+              </ul>
+            </div>
+
+            <div class="info-card p-6">
+              <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-[--text-muted]">Focus Areas</h2>
+              <ul class="mt-4 space-y-3 text-sm text-[--text-dark]">
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--secondary-color]"></span>
+                  <span>Integration of big data workflows with epidemiological surveillance</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--secondary-color]"></span>
+                  <span>Applied statistics for behavioral and social determinants of health</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--secondary-color]"></span>
+                  <span>Design of digital tools that advance equity-driven decision making</span>
+                </li>
+              </ul>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </section>
+
+    <section class="mt-16 border-t border-slate-200/70 bg-[--bg-secondary]/90 py-12">
+      <div class="mx-auto max-w-6xl px-6">
+        <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 class="text-2xl font-semibold text-[--text-dark]">Explore other GPIS researchers</h2>
+            <p class="mt-2 text-sm text-[--text-muted]">Browse the full network to learn more about our multidisciplinary team.</p>
+          </div>
+          <a href="../index.html#members" class="inline-flex items-center gap-2 rounded-full border border-sky-200 bg-[--bg-secondary] px-4 py-2 text-sm font-semibold text-[--primary-color] shadow-sm transition hover:border-[--primary-color] hover:text-[--secondary-color]">Return to directory</a>
+        </div>
+        <div class="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <a href="christian-loret-de-mola-zanatti.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Life-course Epidemiology</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Christian Loret de Mola Zanatti</h3>
+          </a>
+          <a href="francine-dos-santos-costa.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Maternal &amp; Child Health</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Francine dos Santos Costa</h3>
+          </a>
+          <a href="thais-martins-da-silva.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Life Course Nutrition</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Thais Martins da Silva</h3>
+          </a>
+          <a href="rafaela-costa-martins.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Physical Activity &amp; Stress</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Rafaela Costa Martins</h3>
+          </a>
+          <a href="romina-buffarini.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Nutrition &amp; Equity</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Romina Buffarini</h3>
+          </a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-slate-200 bg-[--bg-secondary]/95 py-8">
+    <div class="mx-auto flex max-w-6xl flex-col gap-4 px-6 text-sm text-[--text-muted] md:flex-row md:items-center md:justify-between">
+      <p>&copy; <span data-current-year></span> GPIS Health Innovation Research Group. All rights reserved.</p>
+      <div class="flex flex-wrap gap-4">
+        <a href="../index.html#contact" class="hover:text-[--primary-color]">Contact</a>
+        <a href="../index.html#news" class="hover:text-[--primary-color]">News</a>
+        <a href="../index.html#projects" class="hover:text-[--primary-color]">Projects</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../assets/js/site.js" defer></script>
+</body>
+</html>

--- a/researchers/christian-loret-de-mola-zanatti.html
+++ b/researchers/christian-loret-de-mola-zanatti.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Christian Loret de Mola Zanatti | GPIS Researcher</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Poppins:wght@500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../assets/css/site.css">
+</head>
+<body class="min-h-screen flex flex-col bg-[--bg-primary]">
+  <header class="fixed inset-x-0 top-0 z-40 border-b border-slate-200/70 bg-[--bg-secondary]/90 backdrop-blur">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+      <a href="../index.html" class="flex items-center gap-3 text-sm text-[--text-muted] transition hover:text-[--primary-color]">
+        <img src="../images/logo.png" alt="GPIS logo" class="h-10 w-auto">
+        <div class="leading-tight">
+          <p class="font-semibold text-[--text-dark]">GPIS</p>
+          <p class="text-xs">Health Innovation Research Group</p>
+        </div>
+      </a>
+      <nav class="hidden items-center gap-6 text-sm font-medium text-[--text-muted] md:flex">
+        <a href="../index.html#members" class="nav-link">Back to Members</a>
+        <a href="../index.html#projects" class="nav-link">Projects</a>
+        <a href="../index.html#news" class="nav-link">News</a>
+        <a href="mailto:chlmz@yahoo.com" class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[--primary-color] to-[--accent-color] px-4 py-2 text-white shadow-sm transition hover:shadow-lg">
+          <span>Contact Christian</span>
+        </a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="flex-1 pt-28 pb-20">
+    <section class="px-6">
+      <div class="mx-auto max-w-6xl section-card p-10 md:p-12">
+        <div class="flex flex-col gap-10 lg:grid lg:grid-cols-[minmax(0,2fr)_minmax(0,1.05fr)] lg:gap-12">
+          <article class="space-y-8">
+            <div class="flex flex-col-reverse gap-8 lg:flex-row lg:items-center lg:justify-between">
+              <div class="space-y-6">
+                <div class="flex flex-wrap items-center gap-3 text-xs font-semibold uppercase tracking-[0.3em] text-[--primary-color]">
+                  <span>Researcher Profile</span>
+                  <span class="hidden h-1 w-14 rounded-full bg-[--accent-color]/70 sm:block"></span>
+                  <span>GPIS</span>
+                </div>
+                <div class="space-y-3">
+                  <h1 class="text-3xl font-bold text-[--text-dark] sm:text-4xl lg:text-5xl">Christian Loret de Mola Zanatti</h1>
+                  <p class="max-w-2xl text-lg text-[--text-muted]">Full Professor at the Federal University of Rio Grande (FURG) and senior researcher at the GPIS Health Innovation Research Group.</p>
+                </div>
+                <div class="flex flex-wrap gap-3">
+                  <span class="tag">Life-course epidemiology</span>
+                  <span class="tag">Mental health</span>
+                  <span class="tag">Birth cohorts</span>
+                  <span class="tag">Global collaboration</span>
+                </div>
+              </div>
+              <div class="flex justify-center lg:justify-end">
+                <div class="relative">
+                  <div class="absolute inset-0 -translate-x-2 translate-y-2 rounded-full bg-gradient-to-br from-[--primary-color]/20 to-[--accent-color]/10 blur-xl"></div>
+                  <img src="../images/christian-loret-de-mola-zanatti.png" alt="Portrait of Christian Loret de Mola Zanatti" class="relative z-10 h-40 w-40 rounded-full object-cover shadow-lg ring-4 ring-[--bg-secondary] outline outline-2 outline-[--primary-color]/20 md:h-48 md:w-48">
+                </div>
+              </div>
+            </div>
+
+            <div class="accent-bar"></div>
+
+            <div class="space-y-6 text-base leading-relaxed text-[--text-muted]">
+              <p>Christian Loret de Mola Zanatti is a physician and epidemiologist whose career bridges clinical practice, advanced quantitative methods, and collaborative public health research. A full professor at the Federal University of Rio Grande (FURG), he earned his PhD in Epidemiology from the Federal University of Pelotas (UFPel) and completed both doctoral and postdoctoral work there. He also holds a master&#39;s degree in Clinical Epidemiology from Universidad Peruana Cayetano Heredia in Peru.</p>
+              <p>Christian investigates the social and biological determinants that shape mental health, with special attention to depression, stress, and how early-life experiences influence wellbeing across the life course. His leadership in long-running birth cohorts and population health studies has produced evidence that connects childhood adversity, biological pathways, and adult mental health outcomes.</p>
+              <p>Through networks such as the CHANGE Research Working Group at Universidad Científica del Sur and international epidemiology consortia, Christian coordinates multi-country collaborations that translate longitudinal research into policies promoting mental health equity.</p>
+            </div>
+          </article>
+
+          <aside class="space-y-6">
+            <div class="info-card p-6">
+              <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-[--text-muted]">Quick Facts</h2>
+              <dl class="mt-4 space-y-4 text-sm text-[--text-dark]">
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">Email</dt>
+                  <dd><a href="mailto:chlmz@yahoo.com" class="text-[--primary-color] hover:text-[--secondary-color]">chlmz@yahoo.com</a></dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">ORCID</dt>
+                  <dd><a href="https://orcid.org/0000-0002-5264-5914" target="_blank" rel="noopener" class="text-[--primary-color] hover:text-[--secondary-color]">0000-0002-5264-5914</a></dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">Lattes ID</dt>
+                  <dd><a href="http://lattes.cnpq.br/8242045446214833" target="_blank" rel="noopener" class="text-[--primary-color] hover:text-[--secondary-color]">8242045446214833</a></dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">CNPq Award</dt>
+                  <dd class="text-right text-sm">Productivity in Research Scholarship (Level C)</dd>
+                </div>
+              </dl>
+              <a href="http://lattes.cnpq.br/8242045446214833" target="_blank" rel="noopener" class="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-full bg-gradient-to-r from-[--primary-color] to-[--accent-color] px-4 py-2 text-sm font-semibold text-white transition hover:shadow-lg">View Curriculum Lattes</a>
+            </div>
+
+            <div class="info-card p-6">
+              <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-[--text-muted]">Affiliations</h2>
+              <ul class="mt-4 space-y-3 text-sm text-[--text-dark]">
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--primary-color]"></span>
+                  <span>Health Innovation Research Group (GPIS), Federal University of Rio Grande (FURG)</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--primary-color]"></span>
+                  <span>Post-Graduate Program in Public Health, FURG</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--primary-color]"></span>
+                  <span>CHANGE Research Working Group, Universidad Científica del Sur</span>
+                </li>
+              </ul>
+            </div>
+
+            <div class="info-card p-6">
+              <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-[--text-muted]">Focus Areas</h2>
+              <ul class="mt-4 space-y-3 text-sm text-[--text-dark]">
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--secondary-color]"></span>
+                  <span>Mental health determinants and resilience across the life course</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--secondary-color]"></span>
+                  <span>Stress biology and depression trajectories in population cohorts</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--secondary-color]"></span>
+                  <span>Global collaborations translating longitudinal evidence into policy</span>
+                </li>
+              </ul>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </section>
+
+    <section class="mt-16 border-t border-slate-200/70 bg-[--bg-secondary]/90 py-12">
+      <div class="mx-auto max-w-6xl px-6">
+        <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 class="text-2xl font-semibold text-[--text-dark]">Explore other GPIS researchers</h2>
+            <p class="mt-2 text-sm text-[--text-muted]">Browse the full network to learn more about our multidisciplinary team.</p>
+          </div>
+          <a href="../index.html#members" class="inline-flex items-center gap-2 rounded-full border border-sky-200 bg-[--bg-secondary] px-4 py-2 text-sm font-semibold text-[--primary-color] shadow-sm transition hover:border-[--primary-color] hover:text-[--secondary-color]">Return to directory</a>
+        </div>
+        <div class="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <a href="cauane-blumenberg-silva.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Data Science &amp; Epidemiology</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Cauane Blumenberg Silva</h3>
+          </a>
+          <a href="francine-dos-santos-costa.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Maternal &amp; Child Health</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Francine dos Santos Costa</h3>
+          </a>
+          <a href="thais-martins-da-silva.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Life Course Nutrition</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Thais Martins da Silva</h3>
+          </a>
+          <a href="rafaela-costa-martins.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Physical Activity &amp; Stress</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Rafaela Costa Martins</h3>
+          </a>
+          <a href="romina-buffarini.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Nutrition &amp; Equity</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Romina Buffarini</h3>
+          </a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-slate-200 bg-[--bg-secondary]/95 py-8">
+    <div class="mx-auto flex max-w-6xl flex-col gap-4 px-6 text-sm text-[--text-muted] md:flex-row md:items-center md:justify-between">
+      <p>&copy; <span data-current-year></span> GPIS Health Innovation Research Group. All rights reserved.</p>
+      <div class="flex flex-wrap gap-4">
+        <a href="../index.html#contact" class="hover:text-[--primary-color]">Contact</a>
+        <a href="../index.html#news" class="hover:text-[--primary-color]">News</a>
+        <a href="../index.html#projects" class="hover:text-[--primary-color]">Projects</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../assets/js/site.js" defer></script>
+</body>
+</html>

--- a/researchers/francine-dos-santos-costa.html
+++ b/researchers/francine-dos-santos-costa.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Francine dos Santos Costa | GPIS Researcher</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Poppins:wght@500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../assets/css/site.css">
+</head>
+<body class="min-h-screen flex flex-col bg-[--bg-primary]">
+  <header class="fixed inset-x-0 top-0 z-40 border-b border-slate-200/70 bg-[--bg-secondary]/90 backdrop-blur">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+      <a href="../index.html" class="flex items-center gap-3 text-sm text-[--text-muted] transition hover:text-[--primary-color]">
+        <img src="../images/logo.png" alt="GPIS logo" class="h-10 w-auto">
+        <div class="leading-tight">
+          <p class="font-semibold text-[--text-dark]">GPIS</p>
+          <p class="text-xs">Health Innovation Research Group</p>
+        </div>
+      </a>
+      <nav class="hidden items-center gap-6 text-sm font-medium text-[--text-muted] md:flex">
+        <a href="../index.html#members" class="nav-link">Back to Members</a>
+        <a href="../index.html#projects" class="nav-link">Projects</a>
+        <a href="../index.html#news" class="nav-link">News</a>
+        <a href="mailto:francinesct@gmail.com" class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[--primary-color] to-[--accent-color] px-4 py-2 text-white shadow-sm transition hover:shadow-lg">
+          <span>Contact Francine</span>
+        </a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="flex-1 pt-28 pb-20">
+    <section class="px-6">
+      <div class="mx-auto max-w-6xl section-card p-10 md:p-12">
+        <div class="flex flex-col gap-10 lg:grid lg:grid-cols-[minmax(0,2fr)_minmax(0,1.05fr)] lg:gap-12">
+          <article class="space-y-8">
+            <div class="flex flex-col-reverse gap-8 lg:flex-row lg:items-center lg:justify-between">
+              <div class="space-y-6">
+                <div class="flex flex-wrap items-center gap-3 text-xs font-semibold uppercase tracking-[0.3em] text-[--primary-color]">
+                  <span>Researcher Profile</span>
+                  <span class="hidden h-1 w-14 rounded-full bg-[--accent-color]/70 sm:block"></span>
+                  <span>GPIS</span>
+                </div>
+                <div class="space-y-3">
+                  <h1 class="text-3xl font-bold text-[--text-dark] sm:text-4xl lg:text-5xl">Francine dos Santos Costa</h1>
+                  <p class="max-w-2xl text-lg text-[--text-muted]">Dental public health researcher advancing maternal-child equity through big-data epidemiology.</p>
+                </div>
+                <div class="flex flex-wrap gap-3">
+                  <span class="tag">Maternal &amp; child health</span>
+                  <span class="tag">Dental public health</span>
+                  <span class="tag">Health equity</span>
+                  <span class="tag">Data-driven policy</span>
+                </div>
+              </div>
+              <div class="flex justify-center lg:justify-end">
+                <div class="relative">
+                  <div class="absolute inset-0 -translate-x-2 translate-y-2 rounded-full bg-gradient-to-br from-[--primary-color]/20 to-[--accent-color]/10 blur-xl"></div>
+                  <img src="../images/Francine_costa.png" alt="Portrait of Francine dos Santos Costa" class="relative z-10 h-40 w-40 rounded-full object-cover shadow-lg ring-4 ring-[--bg-secondary] outline outline-2 outline-[--primary-color]/20 md:h-48 md:w-48">
+                </div>
+              </div>
+            </div>
+
+            <div class="accent-bar"></div>
+
+            <div class="space-y-6 text-base leading-relaxed text-[--text-muted]">
+              <p>Francine dos Santos Costa is a dental surgeon with dual doctorates in Dentistry and Epidemiology, complemented by a postdoctoral fellowship in Collective Health. At the International Center for Equity in Health (ICEH), she leads analyses that illuminate structural barriers to quality oral and maternal-child care.</p>
+              <p>Combining clinical expertise with advanced epidemiological modeling, Francine explores how social determinants and early-life conditions shape oral health trajectories. Her portfolio spans large-scale cohort studies, international collaborations, and the use of data science to design interventions that improve outcomes in vulnerable communities.</p>
+              <p>As a CNPq Technological Development Scholarship recipient (Level A), Francine champions evidence that bridges dental practice, equity-focused policy, and the integration of oral health into broader public health agendas.</p>
+            </div>
+          </article>
+
+          <aside class="space-y-6">
+            <div class="info-card p-6">
+              <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-[--text-muted]">Quick Facts</h2>
+              <dl class="mt-4 space-y-4 text-sm text-[--text-dark]">
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">Email</dt>
+                  <dd><a href="mailto:francinesct@gmail.com" class="text-[--primary-color] hover:text-[--secondary-color]">francinesct@gmail.com</a></dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">ORCID</dt>
+                  <dd><a href="https://orcid.org/0000-0001-9558-937X" target="_blank" rel="noopener" class="text-[--primary-color] hover:text-[--secondary-color]">0000-0001-9558-937X</a></dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">Lattes ID</dt>
+                  <dd><a href="http://lattes.cnpq.br/3616089720752945" target="_blank" rel="noopener" class="text-[--primary-color] hover:text-[--secondary-color]">3616089720752945</a></dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">CNPq Award</dt>
+                  <dd class="text-right text-sm">Technological Development Scholarship (Level A)</dd>
+                </div>
+              </dl>
+              <a href="http://lattes.cnpq.br/3616089720752945" target="_blank" rel="noopener" class="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-full bg-gradient-to-r from-[--primary-color] to-[--accent-color] px-4 py-2 text-sm font-semibold text-white transition hover:shadow-lg">View Curriculum Lattes</a>
+            </div>
+
+            <div class="info-card p-6">
+              <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-[--text-muted]">Affiliations</h2>
+              <ul class="mt-4 space-y-3 text-sm text-[--text-dark]">
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--primary-color]"></span>
+                  <span>Health Innovation Research Group (GPIS), Federal University of Rio Grande (FURG)</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--primary-color]"></span>
+                  <span>Federal University of Pelotas, Center for Equity</span>
+                </li>
+              </ul>
+            </div>
+
+            <div class="info-card p-6">
+              <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-[--text-muted]">Focus Areas</h2>
+              <ul class="mt-4 space-y-3 text-sm text-[--text-dark]">
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--secondary-color]"></span>
+                  <span>Inequalities in oral health and maternal-child care access</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--secondary-color]"></span>
+                  <span>Population-based cohort studies focused on early-life development</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--secondary-color]"></span>
+                  <span>Translation of dental epidemiology into public policy guidance</span>
+                </li>
+              </ul>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </section>
+
+    <section class="mt-16 border-t border-slate-200/70 bg-[--bg-secondary]/90 py-12">
+      <div class="mx-auto max-w-6xl px-6">
+        <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 class="text-2xl font-semibold text-[--text-dark]">Explore other GPIS researchers</h2>
+            <p class="mt-2 text-sm text-[--text-muted]">Browse the full network to learn more about our multidisciplinary team.</p>
+          </div>
+          <a href="../index.html#members" class="inline-flex items-center gap-2 rounded-full border border-sky-200 bg-[--bg-secondary] px-4 py-2 text-sm font-semibold text-[--primary-color] shadow-sm transition hover:border-[--primary-color] hover:text-[--secondary-color]">Return to directory</a>
+        </div>
+        <div class="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <a href="christian-loret-de-mola-zanatti.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Life-course Epidemiology</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Christian Loret de Mola Zanatti</h3>
+          </a>
+          <a href="cauane-blumenberg-silva.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Data Science &amp; Epidemiology</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Cauane Blumenberg Silva</h3>
+          </a>
+          <a href="thais-martins-da-silva.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Life Course Nutrition</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Thais Martins da Silva</h3>
+          </a>
+          <a href="rafaela-costa-martins.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Physical Activity &amp; Stress</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Rafaela Costa Martins</h3>
+          </a>
+          <a href="romina-buffarini.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Nutrition &amp; Equity</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Romina Buffarini</h3>
+          </a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-slate-200 bg-[--bg-secondary]/95 py-8">
+    <div class="mx-auto flex max-w-6xl flex-col gap-4 px-6 text-sm text-[--text-muted] md:flex-row md:items-center md:justify-between">
+      <p>&copy; <span data-current-year></span> GPIS Health Innovation Research Group. All rights reserved.</p>
+      <div class="flex flex-wrap gap-4">
+        <a href="../index.html#contact" class="hover:text-[--primary-color]">Contact</a>
+        <a href="../index.html#news" class="hover:text-[--primary-color]">News</a>
+        <a href="../index.html#projects" class="hover:text-[--primary-color]">Projects</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../assets/js/site.js" defer></script>
+</body>
+</html>

--- a/researchers/rafaela-costa-martins.html
+++ b/researchers/rafaela-costa-martins.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Rafaela Costa Martins | GPIS Researcher</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Poppins:wght@500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../assets/css/site.css">
+</head>
+<body class="min-h-screen flex flex-col bg-[--bg-primary]">
+  <header class="fixed inset-x-0 top-0 z-40 border-b border-slate-200/70 bg-[--bg-secondary]/90 backdrop-blur">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+      <a href="../index.html" class="flex items-center gap-3 text-sm text-[--text-muted] transition hover:text-[--primary-color]">
+        <img src="../images/logo.png" alt="GPIS logo" class="h-10 w-auto">
+        <div class="leading-tight">
+          <p class="font-semibold text-[--text-dark]">GPIS</p>
+          <p class="text-xs">Health Innovation Research Group</p>
+        </div>
+      </a>
+      <nav class="hidden items-center gap-6 text-sm font-medium text-[--text-muted] md:flex">
+        <a href="../index.html#members" class="nav-link">Back to Members</a>
+        <a href="../index.html#projects" class="nav-link">Projects</a>
+        <a href="../index.html#news" class="nav-link">News</a>
+        <a href="mailto:rafamartins1@gmail.com" class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[--primary-color] to-[--accent-color] px-4 py-2 text-white shadow-sm transition hover:shadow-lg">
+          <span>Contact Rafaela</span>
+        </a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="flex-1 pt-28 pb-20">
+    <section class="px-6">
+      <div class="mx-auto max-w-6xl section-card p-10 md:p-12">
+        <div class="flex flex-col gap-10 lg:grid lg:grid-cols-[minmax(0,2fr)_minmax(0,1.05fr)] lg:gap-12">
+          <article class="space-y-8">
+            <div class="flex flex-col-reverse gap-8 lg:flex-row lg:items-center lg:justify-between">
+              <div class="space-y-6">
+                <div class="flex flex-wrap items-center gap-3 text-xs font-semibold uppercase tracking-[0.3em] text-[--primary-color]">
+                  <span>Researcher Profile</span>
+                  <span class="hidden h-1 w-14 rounded-full bg-[--accent-color]/70 sm:block"></span>
+                  <span>GPIS</span>
+                </div>
+                <div class="space-y-3">
+                  <h1 class="text-3xl font-bold text-[--text-dark] sm:text-4xl lg:text-5xl">Rafaela Costa Martins</h1>
+                  <p class="max-w-2xl text-lg text-[--text-muted]">Epidemiologist examining how physical activity, stress, and violence shape health across the life span.</p>
+                </div>
+                <div class="flex flex-wrap gap-3">
+                  <span class="tag">Physical activity</span>
+                  <span class="tag">Stress biomarkers</span>
+                  <span class="tag">Violence prevention</span>
+                  <span class="tag">Project leadership</span>
+                </div>
+              </div>
+              <div class="flex justify-center lg:justify-end">
+                <div class="relative">
+                  <div class="absolute inset-0 -translate-x-2 translate-y-2 rounded-full bg-gradient-to-br from-[--primary-color]/20 to-[--accent-color]/10 blur-xl"></div>
+                  <img src="../images/rafaela_martins.png" alt="Portrait of Rafaela Costa Martins" class="relative z-10 h-40 w-40 rounded-full object-cover shadow-lg ring-4 ring-[--bg-secondary] outline outline-2 outline-[--primary-color]/20 md:h-48 md:w-48">
+                </div>
+              </div>
+            </div>
+
+            <div class="accent-bar"></div>
+
+            <div class="space-y-6 text-base leading-relaxed text-[--text-muted]">
+              <p>Rafaela Costa Martins is an epidemiologist with training in Physical Education from the Federal University of Pelotas (UFPel), where she also completed her doctorate and postdoctoral research. She brings international experience from McMaster University (Canada) to the Human Development and Violence Research Centre (DOVE).</p>
+              <p>As a project manager and partner at Causale Consultoria, Rafaela coordinates multidisciplinary teams that study how movement behaviors, adversity, and mental health intersect. Her work combines accelerometry, biomarker analysis, and community-engaged research to understand the impacts of violence and stress on development.</p>
+              <p>Rafaela contributes to global networks including the Global Observatory for Physical Activity (GoPA!) and the Accelerometry Studies Group (GEPEA), advancing evidence that connects physical activity promotion with mental health resilience.</p>
+            </div>
+          </article>
+
+          <aside class="space-y-6">
+            <div class="info-card p-6">
+              <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-[--text-muted]">Quick Facts</h2>
+              <dl class="mt-4 space-y-4 text-sm text-[--text-dark]">
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">Email</dt>
+                  <dd><a href="mailto:rafamartins1@gmail.com" class="text-[--primary-color] hover:text-[--secondary-color]">rafamartins1@gmail.com</a></dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">ORCID</dt>
+                  <dd><a href="https://orcid.org/0000-0003-3538-7228" target="_blank" rel="noopener" class="text-[--primary-color] hover:text-[--secondary-color]">0000-0003-3538-7228</a></dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">Lattes ID</dt>
+                  <dd><a href="http://lattes.cnpq.br/9081352706955381" target="_blank" rel="noopener" class="text-[--primary-color] hover:text-[--secondary-color]">9081352706955381</a></dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">CNPq Award</dt>
+                  <dd class="text-right text-sm text-[--text-muted]">Not currently listed</dd>
+                </div>
+              </dl>
+              <a href="http://lattes.cnpq.br/9081352706955381" target="_blank" rel="noopener" class="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-full bg-gradient-to-r from-[--primary-color] to-[--accent-color] px-4 py-2 text-sm font-semibold text-white transition hover:shadow-lg">View Curriculum Lattes</a>
+            </div>
+
+            <div class="info-card p-6">
+              <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-[--text-muted]">Affiliations</h2>
+              <ul class="mt-4 space-y-3 text-sm text-[--text-dark]">
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--primary-color]"></span>
+                  <span>Health Innovation Research Group (GPIS), Federal University of Rio Grande (FURG)</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--primary-color]"></span>
+                  <span>Human Development and Violence Research Centre (DOVE), Federal University of Pelotas (UFPel)</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--primary-color]"></span>
+                  <span>Causale Consultoria</span>
+                </li>
+              </ul>
+            </div>
+
+            <div class="info-card p-6">
+              <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-[--text-muted]">Focus Areas</h2>
+              <ul class="mt-4 space-y-3 text-sm text-[--text-dark]">
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--secondary-color]"></span>
+                  <span>Physical activity promotion for mental health and resilience</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--secondary-color]"></span>
+                  <span>Violence prevention strategies grounded in epidemiological evidence</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--secondary-color]"></span>
+                  <span>Biomarkers of stress and behavior across developmental stages</span>
+                </li>
+              </ul>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </section>
+
+    <section class="mt-16 border-t border-slate-200/70 bg-[--bg-secondary]/90 py-12">
+      <div class="mx-auto max-w-6xl px-6">
+        <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 class="text-2xl font-semibold text-[--text-dark]">Explore other GPIS researchers</h2>
+            <p class="mt-2 text-sm text-[--text-muted]">Browse the full network to learn more about our multidisciplinary team.</p>
+          </div>
+          <a href="../index.html#members" class="inline-flex items-center gap-2 rounded-full border border-sky-200 bg-[--bg-secondary] px-4 py-2 text-sm font-semibold text-[--primary-color] shadow-sm transition hover:border-[--primary-color] hover:text-[--secondary-color]">Return to directory</a>
+        </div>
+        <div class="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <a href="christian-loret-de-mola-zanatti.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Life-course Epidemiology</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Christian Loret de Mola Zanatti</h3>
+          </a>
+          <a href="cauane-blumenberg-silva.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Data Science &amp; Epidemiology</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Cauane Blumenberg Silva</h3>
+          </a>
+          <a href="francine-dos-santos-costa.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Maternal &amp; Child Health</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Francine dos Santos Costa</h3>
+          </a>
+          <a href="thais-martins-da-silva.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Life Course Nutrition</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Thais Martins da Silva</h3>
+          </a>
+          <a href="romina-buffarini.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Nutrition &amp; Equity</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Romina Buffarini</h3>
+          </a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-slate-200 bg-[--bg-secondary]/95 py-8">
+    <div class="mx-auto flex max-w-6xl flex-col gap-4 px-6 text-sm text-[--text-muted] md:flex-row md:items-center md:justify-between">
+      <p>&copy; <span data-current-year></span> GPIS Health Innovation Research Group. All rights reserved.</p>
+      <div class="flex flex-wrap gap-4">
+        <a href="../index.html#contact" class="hover:text-[--primary-color]">Contact</a>
+        <a href="../index.html#news" class="hover:text-[--primary-color]">News</a>
+        <a href="../index.html#projects" class="hover:text-[--primary-color]">Projects</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../assets/js/site.js" defer></script>
+</body>
+</html>

--- a/researchers/romina-buffarini.html
+++ b/researchers/romina-buffarini.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Romina Buffarini | GPIS Researcher</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Poppins:wght@500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../assets/css/site.css">
+</head>
+<body class="min-h-screen flex flex-col bg-[--bg-primary]">
+  <header class="fixed inset-x-0 top-0 z-40 border-b border-slate-200/70 bg-[--bg-secondary]/90 backdrop-blur">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+      <a href="../index.html" class="flex items-center gap-3 text-sm text-[--text-muted] transition hover:text-[--primary-color]">
+        <img src="../images/logo.png" alt="GPIS logo" class="h-10 w-auto">
+        <div class="leading-tight">
+          <p class="font-semibold text-[--text-dark]">GPIS</p>
+          <p class="text-xs">Health Innovation Research Group</p>
+        </div>
+      </a>
+      <nav class="hidden items-center gap-6 text-sm font-medium text-[--text-muted] md:flex">
+        <a href="../index.html#members" class="nav-link">Back to Members</a>
+        <a href="../index.html#projects" class="nav-link">Projects</a>
+        <a href="../index.html#news" class="nav-link">News</a>
+        <a href="mailto:romibuffarini@gmail.com" class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[--primary-color] to-[--accent-color] px-4 py-2 text-white shadow-sm transition hover:shadow-lg">
+          <span>Contact Romina</span>
+        </a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="flex-1 pt-28 pb-20">
+    <section class="px-6">
+      <div class="mx-auto max-w-6xl section-card p-10 md:p-12">
+        <div class="flex flex-col gap-10 lg:grid lg:grid-cols-[minmax(0,2fr)_minmax(0,1.05fr)] lg:gap-12">
+          <article class="space-y-8">
+            <div class="flex flex-col-reverse gap-8 lg:flex-row lg:items-center lg:justify-between">
+              <div class="space-y-6">
+                <div class="flex flex-wrap items-center gap-3 text-xs font-semibold uppercase tracking-[0.3em] text-[--primary-color]">
+                  <span>Researcher Profile</span>
+                  <span class="hidden h-1 w-14 rounded-full bg-[--accent-color]/70 sm:block"></span>
+                  <span>GPIS</span>
+                </div>
+                <div class="space-y-3">
+                  <h1 class="text-3xl font-bold text-[--text-dark] sm:text-4xl lg:text-5xl">Romina Buffarini</h1>
+                  <p class="max-w-2xl text-lg text-[--text-muted]">Nutrition epidemiologist advancing maternal-child health and food equity across the Americas.</p>
+                </div>
+                <div class="flex flex-wrap gap-3">
+                  <span class="tag">Maternal &amp; child nutrition</span>
+                  <span class="tag">Food policy</span>
+                  <span class="tag">Health equity</span>
+                  <span class="tag">Global partnerships</span>
+                </div>
+              </div>
+              <div class="flex justify-center lg:justify-end">
+                <div class="relative">
+                  <div class="absolute inset-0 -translate-x-2 translate-y-2 rounded-full bg-gradient-to-br from-[--primary-color]/20 to-[--accent-color]/10 blur-xl"></div>
+                  <img src="../images/romina_buffarini.png" alt="Portrait of Romina Buffarini" class="relative z-10 h-40 w-40 rounded-full object-cover shadow-lg ring-4 ring-[--bg-secondary] outline outline-2 outline-[--primary-color]/20 md:h-48 md:w-48">
+                </div>
+              </div>
+            </div>
+
+            <div class="accent-bar"></div>
+
+            <div class="space-y-6 text-base leading-relaxed text-[--text-muted]">
+              <p>Romina Buffarini is an Argentine nutritionist with a PhD in Epidemiology from the Federal University of Pelotas (UFPel). She is a visiting professor in the Graduate Program in Health Sciences at FURG and a researcher with the Human Development and Violence Research Centre (DOVE).</p>
+              <p>Romina&#39;s research examines maternal-child nutrition, dietary patterns, and the role of social inequalities in shaping health trajectories. She works with interdisciplinary teams to design evidence-based strategies that support healthy eating and equitable policy implementation.</p>
+              <p>International collaborations, including work at the Centre for Global Child Health at the Hospital for Sick Children (Toronto), inform Romina&#39;s cross-cultural approach to nutrition and public health advocacy.</p>
+            </div>
+          </article>
+
+          <aside class="space-y-6">
+            <div class="info-card p-6">
+              <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-[--text-muted]">Quick Facts</h2>
+              <dl class="mt-4 space-y-4 text-sm text-[--text-dark]">
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">Email</dt>
+                  <dd><a href="mailto:romibuffarini@gmail.com" class="text-[--primary-color] hover:text-[--secondary-color]">romibuffarini@gmail.com</a></dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">ORCID</dt>
+                  <dd><a href="https://orcid.org/0000-0002-6905-8767" target="_blank" rel="noopener" class="text-[--primary-color] hover:text-[--secondary-color]">0000-0002-6905-8767</a></dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">Lattes ID</dt>
+                  <dd><a href="http://lattes.cnpq.br/7988530452919981" target="_blank" rel="noopener" class="text-[--primary-color] hover:text-[--secondary-color]">7988530452919981</a></dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">CNPq Award</dt>
+                  <dd class="text-right text-sm text-[--text-muted]">Not currently listed</dd>
+                </div>
+              </dl>
+              <a href="http://lattes.cnpq.br/7988530452919981" target="_blank" rel="noopener" class="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-full bg-gradient-to-r from-[--primary-color] to-[--accent-color] px-4 py-2 text-sm font-semibold text-white transition hover:shadow-lg">View Curriculum Lattes</a>
+            </div>
+
+            <div class="info-card p-6">
+              <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-[--text-muted]">Affiliations</h2>
+              <ul class="mt-4 space-y-3 text-sm text-[--text-dark]">
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--primary-color]"></span>
+                  <span>Health Innovation Research Group (GPIS), Federal University of Rio Grande (FURG)</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--primary-color]"></span>
+                  <span>Human Development and Violence Research Centre (DOVE), Federal University of Pelotas (UFPel)</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--primary-color]"></span>
+                  <span>Graduate Program in Health Sciences, Federal University of Rio Grande (FURG)</span>
+                </li>
+              </ul>
+            </div>
+
+            <div class="info-card p-6">
+              <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-[--text-muted]">Focus Areas</h2>
+              <ul class="mt-4 space-y-3 text-sm text-[--text-dark]">
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--secondary-color]"></span>
+                  <span>Maternal-child nutrition and growth trajectories</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--secondary-color]"></span>
+                  <span>Social determinants of healthy eating and food insecurity</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--secondary-color]"></span>
+                  <span>International collaborations for equitable health policy</span>
+                </li>
+              </ul>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </section>
+
+    <section class="mt-16 border-t border-slate-200/70 bg-[--bg-secondary]/90 py-12">
+      <div class="mx-auto max-w-6xl px-6">
+        <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 class="text-2xl font-semibold text-[--text-dark]">Explore other GPIS researchers</h2>
+            <p class="mt-2 text-sm text-[--text-muted]">Browse the full network to learn more about our multidisciplinary team.</p>
+          </div>
+          <a href="../index.html#members" class="inline-flex items-center gap-2 rounded-full border border-sky-200 bg-[--bg-secondary] px-4 py-2 text-sm font-semibold text-[--primary-color] shadow-sm transition hover:border-[--primary-color] hover:text-[--secondary-color]">Return to directory</a>
+        </div>
+        <div class="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <a href="christian-loret-de-mola-zanatti.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Life-course Epidemiology</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Christian Loret de Mola Zanatti</h3>
+          </a>
+          <a href="cauane-blumenberg-silva.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Data Science &amp; Epidemiology</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Cauane Blumenberg Silva</h3>
+          </a>
+          <a href="francine-dos-santos-costa.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Maternal &amp; Child Health</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Francine dos Santos Costa</h3>
+          </a>
+          <a href="thais-martins-da-silva.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Life Course Nutrition</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Thais Martins da Silva</h3>
+          </a>
+          <a href="rafaela-costa-martins.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Physical Activity &amp; Stress</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Rafaela Costa Martins</h3>
+          </a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-slate-200 bg-[--bg-secondary]/95 py-8">
+    <div class="mx-auto flex max-w-6xl flex-col gap-4 px-6 text-sm text-[--text-muted] md:flex-row md:items-center md:justify-between">
+      <p>&copy; <span data-current-year></span> GPIS Health Innovation Research Group. All rights reserved.</p>
+      <div class="flex flex-wrap gap-4">
+        <a href="../index.html#contact" class="hover:text-[--primary-color]">Contact</a>
+        <a href="../index.html#news" class="hover:text-[--primary-color]">News</a>
+        <a href="../index.html#projects" class="hover:text-[--primary-color]">Projects</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../assets/js/site.js" defer></script>
+</body>
+</html>

--- a/researchers/thais-martins-da-silva.html
+++ b/researchers/thais-martins-da-silva.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Thais Martins da Silva | GPIS Researcher</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Poppins:wght@500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../assets/css/site.css">
+</head>
+<body class="min-h-screen flex flex-col bg-[--bg-primary]">
+  <header class="fixed inset-x-0 top-0 z-40 border-b border-slate-200/70 bg-[--bg-secondary]/90 backdrop-blur">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+      <a href="../index.html" class="flex items-center gap-3 text-sm text-[--text-muted] transition hover:text-[--primary-color]">
+        <img src="../images/logo.png" alt="GPIS logo" class="h-10 w-auto">
+        <div class="leading-tight">
+          <p class="font-semibold text-[--text-dark]">GPIS</p>
+          <p class="text-xs">Health Innovation Research Group</p>
+        </div>
+      </a>
+      <nav class="hidden items-center gap-6 text-sm font-medium text-[--text-muted] md:flex">
+        <a href="../index.html#members" class="nav-link">Back to Members</a>
+        <a href="../index.html#projects" class="nav-link">Projects</a>
+        <a href="../index.html#news" class="nav-link">News</a>
+        <a href="mailto:thaismartins88@hotmail.com" class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[--primary-color] to-[--accent-color] px-4 py-2 text-white shadow-sm transition hover:shadow-lg">
+          <span>Contact Thais</span>
+        </a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="flex-1 pt-28 pb-20">
+    <section class="px-6">
+      <div class="mx-auto max-w-6xl section-card p-10 md:p-12">
+        <div class="flex flex-col gap-10 lg:grid lg:grid-cols-[minmax(0,2fr)_minmax(0,1.05fr)] lg:gap-12">
+          <article class="space-y-8">
+            <div class="flex flex-col-reverse gap-8 lg:flex-row lg:items-center lg:justify-between">
+              <div class="space-y-6">
+                <div class="flex flex-wrap items-center gap-3 text-xs font-semibold uppercase tracking-[0.3em] text-[--primary-color]">
+                  <span>Researcher Profile</span>
+                  <span class="hidden h-1 w-14 rounded-full bg-[--accent-color]/70 sm:block"></span>
+                  <span>GPIS</span>
+                </div>
+                <div class="space-y-3">
+                  <h1 class="text-3xl font-bold text-[--text-dark] sm:text-4xl lg:text-5xl">Thais Martins da Silva</h1>
+                  <p class="max-w-2xl text-lg text-[--text-muted]">Nutrition scientist investigating life-course determinants of wellbeing through genomic and machine learning approaches.</p>
+                </div>
+                <div class="flex flex-wrap gap-3">
+                  <span class="tag">Maternal &amp; child health</span>
+                  <span class="tag">Nutritional epidemiology</span>
+                  <span class="tag">Genomics</span>
+                  <span class="tag">Machine learning</span>
+                </div>
+              </div>
+              <div class="flex justify-center lg:justify-end">
+                <div class="relative">
+                  <div class="absolute inset-0 -translate-x-2 translate-y-2 rounded-full bg-gradient-to-br from-[--primary-color]/20 to-[--accent-color]/10 blur-xl"></div>
+                  <img src="../images/thais_martins.png" alt="Portrait of Thais Martins da Silva" class="relative z-10 h-40 w-40 rounded-full object-cover shadow-lg ring-4 ring-[--bg-secondary] outline outline-2 outline-[--primary-color]/20 md:h-48 md:w-48">
+                </div>
+              </div>
+            </div>
+
+            <div class="accent-bar"></div>
+
+            <div class="space-y-6 text-base leading-relaxed text-[--text-muted]">
+              <p>Thais Martins da Silva is a nutritionist and epidemiologist with a PhD from the Federal University of Pelotas (UFPel). She is a postdoctoral fellow at the University of São Paulo&#39;s School of Medicine and collaborates with the GPIS Health Innovation Research Group at FURG.</p>
+              <p>Her research explores maternal-child health, mental health, and developmental determinants across the life span. Thais integrates multi-omics datasets, advanced statistical modeling, and machine learning to reveal pathways that connect early nutrition, psychosocial factors, and long-term wellbeing.</p>
+              <p>As a CNPq Technological Development Scholarship awardee (Level A), Thais contributes to interdisciplinary teams at the Human Development and Violence Research Centre (DOVE) and the ProDAH group (UFRGS), strengthening prevention strategies and evidence-based interventions for families.</p>
+            </div>
+          </article>
+
+          <aside class="space-y-6">
+            <div class="info-card p-6">
+              <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-[--text-muted]">Quick Facts</h2>
+              <dl class="mt-4 space-y-4 text-sm text-[--text-dark]">
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">Email</dt>
+                  <dd><a href="mailto:thaismartins88@hotmail.com" class="text-[--primary-color] hover:text-[--secondary-color]">thaismartins88@hotmail.com</a></dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">ORCID</dt>
+                  <dd><a href="https://orcid.org/0000-0001-5049-2435" target="_blank" rel="noopener" class="text-[--primary-color] hover:text-[--secondary-color]">0000-0001-5049-2435</a></dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">Lattes ID</dt>
+                  <dd><a href="http://lattes.cnpq.br/9263467453151527" target="_blank" rel="noopener" class="text-[--primary-color] hover:text-[--secondary-color]">9263467453151527</a></dd>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <dt class="text-[--text-muted]">CNPq Award</dt>
+                  <dd class="text-right text-sm">Technological Development Scholarship (Level A)</dd>
+                </div>
+              </dl>
+              <a href="http://lattes.cnpq.br/9263467453151527" target="_blank" rel="noopener" class="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-full bg-gradient-to-r from-[--primary-color] to-[--accent-color] px-4 py-2 text-sm font-semibold text-white transition hover:shadow-lg">View Curriculum Lattes</a>
+            </div>
+
+            <div class="info-card p-6">
+              <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-[--text-muted]">Affiliations</h2>
+              <ul class="mt-4 space-y-3 text-sm text-[--text-dark]">
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--primary-color]"></span>
+                  <span>Health Innovation Research Group (GPIS), Federal University of Rio Grande (FURG)</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--primary-color]"></span>
+                  <span>Human Development and Violence Research Centre (DOVE), Federal University of Pelotas (UFPel)</span>
+                </li>
+              </ul>
+            </div>
+
+            <div class="info-card p-6">
+              <h2 class="text-xs font-semibold uppercase tracking-[0.3em] text-[--text-muted]">Focus Areas</h2>
+              <ul class="mt-4 space-y-3 text-sm text-[--text-dark]">
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--secondary-color]"></span>
+                  <span>Life-course nutrition and maternal-infant wellbeing</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--secondary-color]"></span>
+                  <span>Biomarkers of mental health and metabolic risk</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[--secondary-color]"></span>
+                  <span>Machine learning and genomics in public health nutrition</span>
+                </li>
+              </ul>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </section>
+
+    <section class="mt-16 border-t border-slate-200/70 bg-[--bg-secondary]/90 py-12">
+      <div class="mx-auto max-w-6xl px-6">
+        <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 class="text-2xl font-semibold text-[--text-dark]">Explore other GPIS researchers</h2>
+            <p class="mt-2 text-sm text-[--text-muted]">Browse the full network to learn more about our multidisciplinary team.</p>
+          </div>
+          <a href="../index.html#members" class="inline-flex items-center gap-2 rounded-full border border-sky-200 bg-[--bg-secondary] px-4 py-2 text-sm font-semibold text-[--primary-color] shadow-sm transition hover:border-[--primary-color] hover:text-[--secondary-color]">Return to directory</a>
+        </div>
+        <div class="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <a href="christian-loret-de-mola-zanatti.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Life-course Epidemiology</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Christian Loret de Mola Zanatti</h3>
+          </a>
+          <a href="cauane-blumenberg-silva.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Data Science &amp; Epidemiology</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Cauane Blumenberg Silva</h3>
+          </a>
+          <a href="francine-dos-santos-costa.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Maternal &amp; Child Health</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Francine dos Santos Costa</h3>
+          </a>
+          <a href="rafaela-costa-martins.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Physical Activity &amp; Stress</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Rafaela Costa Martins</h3>
+          </a>
+          <a href="romina-buffarini.html" class="group rounded-2xl border border-slate-200 bg-[--bg-secondary] p-5 shadow-sm transition hover:-translate-y-1 hover:border-[--primary-color] hover:shadow-lg">
+            <p class="text-sm font-semibold text-[--text-muted]">Nutrition &amp; Equity</p>
+            <h3 class="mt-1 text-lg font-semibold text-[--text-dark] group-hover:text-[--primary-color]">Romina Buffarini</h3>
+          </a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-slate-200 bg-[--bg-secondary]/95 py-8">
+    <div class="mx-auto flex max-w-6xl flex-col gap-4 px-6 text-sm text-[--text-muted] md:flex-row md:items-center md:justify-between">
+      <p>&copy; <span data-current-year></span> GPIS Health Innovation Research Group. All rights reserved.</p>
+      <div class="flex flex-wrap gap-4">
+        <a href="../index.html#contact" class="hover:text-[--primary-color]">Contact</a>
+        <a href="../index.html#news" class="hover:text-[--primary-color]">News</a>
+        <a href="../index.html#projects" class="hover:text-[--primary-color]">Projects</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../assets/js/site.js" defer></script>
+</body>
+</html>

--- a/tests/hero-slider.spec.ts
+++ b/tests/hero-slider.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const activeClassPattern = /(?:^|\s)active(?:\s|$)/;
+const whiteDotClassPattern = /(?:^|\s)bg-white(?:\s|$)/;
+
+test.describe('Hero Slider', () => {
+  test('should automatically rotate to the second slide', async ({ page }) => {
+    const filePath = path.join(process.cwd(), 'index.html');
+    const fileUrl = pathToFileURL(filePath).href;
+
+    await page.goto(fileUrl);
+
+    const slides = await page.locator('#home .slide').all();
+    const dots = await page.locator('.slider-dots button').all();
+
+    await expect(slides[0]).toHaveClass(activeClassPattern);
+    await expect(dots[0]).toHaveClass(whiteDotClassPattern);
+    await expect(slides[1]).not.toHaveClass(activeClassPattern);
+    await expect(dots[1]).not.toHaveClass(whiteDotClassPattern);
+
+    await page.waitForTimeout(7100);
+
+    await expect(slides[0]).not.toHaveClass(activeClassPattern);
+    await expect(dots[0]).not.toHaveClass(whiteDotClassPattern);
+    await expect(slides[1]).toHaveClass(activeClassPattern);
+    await expect(dots[1]).toHaveClass(whiteDotClassPattern);
+  });
+});


### PR DESCRIPTION
## Summary
- restyled each researcher profile page to reuse the landing page color palette, typography, and minimal card layout while adding dedicated portrait slots
- kept the biography, quick facts, affiliations, and focus area content in streamlined info cards for Christian, Cauane, Francine, Rafaela, Thais, and Romina
- updated the main landing page member tiles to link directly to the new researcher detail pages
- centralized the shared styling tokens and interaction logic into reusable `assets/css/site.css` and `assets/js/site.js`, updating every page to reference the common files

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e3c1656c708330bd133b53edd0a8d7